### PR TITLE
Add jitpack.io compilation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,18 @@ After that each time you want to make sure if permissions are still there - `Nam
 As library monitors your Permissions at any point of time (just call `init()`) you can get list of monitored Persmissions -`Nammu.getPrevPermissions()`, removed some `Nammu.removePermission(PermissionString)`, or check if is monitored `Nammu.containsPermission(PermissionString)`.
 
 ###How to import it?
-As for now it is NOT hosted at Maven/JCenter etc. as it is based on preview build of Android M which SDK is not available on those platforms. Till that time just copy/paste all classes from library module or even whole module.
+As for now it is NOT hosted at Maven/JCenter etc. as it is based on preview build of Android M which SDK is not available on those platforms. Till that time, it is available on jitpack.io by adding this to your build.gradle:
+
+```groovy
+repositories {
+    maven {
+        url "https://jitpack.io"
+    }
+}
+
+dependencies {
+    compile 'com.github.tajchert:Nammu:<VERSION>'
+}
+```
+
+*The current version is `0.1.0`*


### PR DESCRIPTION
While the repo is not yet available on Maven, you can still use jitpack.io to compile it through gradle
