### PR TITLE
Slightly refactored getting permissions set from granted permission list

### DIFF
--- a/nammu/src/main/java/pl/tajchert/nammu/Nammu.java
+++ b/nammu/src/main/java/pl/tajchert/nammu/Nammu.java
@@ -194,10 +194,7 @@ public class Nammu {
      */
     public static void refreshMonitoredList() {
         ArrayList<String> permissions = getGrantedPermissions();
-        Set<String> set = new HashSet<String>();
-        for(String perm : permissions) {
-            set.add(perm);
-        }
+        Set<String> set = new HashSet<String>(permissions);
         sharedPreferences.edit().putStringSet(KEY_PREV_PERMISSIONS, set).apply();
     }
 


### PR DESCRIPTION
There is no need to write explicit cycle with adding elements from one collection to another. HashSet already has constructor with Collection parameter. Moreover it creates set with initial capacity through this constructor, so it also performance improvement.
